### PR TITLE
Fix "Rolltate" text

### DIFF
--- a/Sphero.Wpf/Views/MainPage.xaml
+++ b/Sphero.Wpf/Views/MainPage.xaml
@@ -48,7 +48,7 @@
                             <TextBlock Text="Rotate (Calibrate)" Grid.Column="1" Grid.Row="0" />
                             <TextBox Text="{Binding RotateAngle, Mode=TwoWay}" Grid.Column="1" Grid.Row="1" />
                             
-                            <TextBlock Text="Roll" Grid.Column="1" Grid.Row="0" />
+                            <TextBlock Text="Roll" Grid.Column="1" Grid.Row="3" />
                             <controls:OnScreenJoystick Angle="{Binding RollAngle, Mode=TwoWay}" Distance="{Binding RollDistance, Mode=TwoWay}" Grid.Column="1" Grid.Row="3" />
                         </Grid>
                     </DataTemplate>


### PR DESCRIPTION
The text for "Roll" and "Rotate" was mistakenly placed on the same row,
causing it to look a little odd. I've moved "Roll" to the row it was
presumably intended to be in.
